### PR TITLE
Don't require history matches in completing-read

### DIFF
--- a/eshell-atuin.el
+++ b/eshell-atuin.el
@@ -394,13 +394,13 @@ Be sure to have the correct `eshell-prompt-regexp' set up!"
   (eshell-atuin--history-update)
   (let* ((commands (eshell-atuin--history-collection))
          (input (eshell-atuin--get-input))
-         (compl (completing-read "History: " commands nil t input))
+         (compl (completing-read "History: " commands nil nil input))
          (command
           (alist-get 'command
                      (gethash compl eshell-atuin--history-cache-format-index))))
     (eshell-bol)
     (delete-region (point) (line-end-position))
-    (insert command)))
+    (insert (or command compl))))
 
 (provide 'eshell-atuin)
 ;;; eshell-atuin.el ends here


### PR DESCRIPTION
First off, thanks for eshell-atuin! It's been great to have my Eshell history in my global history file, and `eshell-atuin-history` has been helpful in adopting Eshell in my work flow. 🙌 

Currently, eshell-atuin's `eshell-atuin-history` doesn't allow inserting commands that aren't yet in the history. This patch proposes unmatched commands are inserted even if they don't match.

Consider the following scenario; you're running eshell-atuin with `eshell-atuin-history` bound to `C-r`. In Eshell, you type part of a command, let's say `ls`. Because the command you're looking for should be in Atuin's database, you press `C-r` and find `ls -l`. That's helpful, but not the full command you're looking for. You press `<tab>` to insert the match and add `ah` to get `ls -lah`, the command you meant to execute. However, after pressing `<ret>`, you find that eshell-atuin won't let you insert a command that's not in the history yet.

This patch flips the `REQUIRE-MATCH` boolean in the `completing-read` call in `eshell-atuin-history` to `nil`, allowing for commands that aren't in the history yet.

The resulting `compl` variable, which holds the command is then used to find the command in the history. This is done to make sure any changes to `eshell-atuin-history-format` don't affect the inserted command. However, because there is no match in the history in this scenario, the `command` variable remains empty.

In the end, what's inserted is either the cleaned `command` variable which mached in the history, or the `compl` variable that didn't match, and is inserted as-is.