### PR TITLE
Use eshell-bol-ignoring-prompt on Emacs 30

### DIFF
--- a/eshell-atuin.el
+++ b/eshell-atuin.el
@@ -128,10 +128,15 @@ include here.  Some examples:
 (defvar eshell-atuin--session-id nil
   "Current atuin session ID.")
 
+(defun eshell-atuin--bol-ignoring-prompt ()
+  (if (fboundp 'eshell-bol-ignoring-prompt)
+      (eshell-bol-ignoring-prompt nil)
+    (beginning-of-line)))
+
 (defun eshell-atuin--get-input ()
   "Get eshell input string on the current line."
   (save-excursion
-    (beginning-of-line)
+    (eshell-atuin--bol-ignoring-prompt)
     (when (looking-at-p eshell-prompt-regexp)
       (substring-no-properties (eshell-get-old-input)))))
 


### PR DESCRIPTION
Currently, the `eshell-atuin--get-input` function uses the `beginning-of-line` function to move the point to the beginning of the line (before the prompt). It then checks if the prompt is present through `looking-at-p` to ensure the current line is a command instead of output that's scrolled back to.

This works on Emacs 29, but the behaviour of the `beginning-of-line` function changed in Emacs 30. There, it doesn't actually move the point before the prompt, but behaves like `eshell-bo`l function (which is also deprecated on Emacs 30, in favor of using `beginning-of-line`).

To get eshell-atuin to work on Emacs 30, it therefor needs to use `eshell-bol-ignoring-prompt` instead of `beginning-of-line`.

This patch adds `eshell-atuin--bol-ignoring-prompt`, which calls `eshell-bol-ignoring-prompt` if available, and falls back to `beginning-of-line` if it doesn't. This fixes compatibility with Emacs 30.